### PR TITLE
Fix typo on function name

### DIFF
--- a/bot/cogs/tcg.py
+++ b/bot/cogs/tcg.py
@@ -42,7 +42,7 @@ class TCG(commands.GroupCog, group_name="warnet-tcg"):
     
     @app_commands.command(name='unregister-member', description='Administrator can unregister a member from TCG leaderboard.')
     @app_commands.describe(member='Member that you want to unregister.')
-    async def tcg_register_member(self, interaction: Interaction, member: discord.Member) -> None:
+    async def tcg_unregister_member(self, interaction: Interaction, member: discord.Member) -> None:
         await unregister_member(self, interaction, member)
 
     @app_commands.command(name='member-stats', description='Member can check their or someone else\'s TCG stats.')


### PR DESCRIPTION
Didn't realize there is a typo there. The function is overriding the previous function
![image](https://user-images.githubusercontent.com/20255031/208288559-f25aa24b-9869-4663-8bdb-dc0322e36946.png)

fix #15  