### PR TITLE
Add new command /sticky re-send and Adding Error handling

### DIFF
--- a/bot/cogs/sticky.py
+++ b/bot/cogs/sticky.py
@@ -140,13 +140,13 @@ class Sticky(commands.GroupCog, group_name="sticky"):
                 data = dict(res[0])
 
                 try:
-                    sticky = await channel.fetch_message(data["message_id"])
+                    sticky_msg = await channel.fetch_message(data["message_id"])
                     message = '\n'.join(message.split('\\n'))
-                    msg = await sticky.edit(content=message)
+                    sticky_data = await sticky_msg.edit(content=message)
                 except discord.errors.NotFound:
-                    sticky = self.bot.get_channel(channel.id)
+                    sticky_channel = self.bot.get_channel(channel.id)
                     message = '\n'.join(message.split('\\n'))
-                    msg = await sticky.send(message)
+                    sticky_data = await sticky_channel.send(message)
 
                 async with self.db_pool.acquire() as conn:
                     await conn.execute(
@@ -155,7 +155,7 @@ class Sticky(commands.GroupCog, group_name="sticky"):
                         message,
                     )
 
-                self.sticky_data[channel.id] = [msg.id, message]
+                self.sticky_data[channel.id] = [sticky_data.id, message]
 
                 await send_interaction(
                     interaction,

--- a/bot/cogs/sticky.py
+++ b/bot/cogs/sticky.py
@@ -285,7 +285,7 @@ class Sticky(commands.GroupCog, group_name="sticky"):
                         message = await channel.fetch_message(sticky["message_id"])
                         await message.delete()
                     except discord.errors.NotFound:
-                        pass
+                        continue
 
                 await conn.execute("TRUNCATE TABLE sticky;")
 

--- a/bot/cogs/sticky.py
+++ b/bot/cogs/sticky.py
@@ -142,11 +142,11 @@ class Sticky(commands.GroupCog, group_name="sticky"):
                 try:
                     sticky = await channel.fetch_message(data["message_id"])
                     message = '\n'.join(message.split('\\n'))
-                    await sticky.edit(content=message)
+                    msg = await sticky.edit(content=message)
                 except discord.errors.NotFound:
                     sticky = self.bot.get_channel(channel.id)
                     message = '\n'.join(message.split('\\n'))
-                    await sticky.send(message)
+                    msg = await sticky.send(message)
 
                 async with self.db_pool.acquire() as conn:
                     await conn.execute(
@@ -155,8 +155,7 @@ class Sticky(commands.GroupCog, group_name="sticky"):
                         message,
                     )
 
-                current_msg_id = self.sticky_data[channel.id][0]
-                self.sticky_data[channel.id] = [current_msg_id, message]
+                self.sticky_data[channel.id] = [msg.id, message]
 
                 await send_interaction(
                     interaction,

--- a/bot/cogs/sticky.py
+++ b/bot/cogs/sticky.py
@@ -246,7 +246,12 @@ class Sticky(commands.GroupCog, group_name="sticky"):
                 data = dict(res[0])
                 try:
                     await channel.fetch_message(data["message_id"])
-                    pass
+                    return await send_interaction(
+                        interaction,
+                        color=discord.Color.red(),
+                        title="❌ Sticky message already exist",
+                        description=f"Sticky message telah terpasang pada channel {channel.mention}",
+                    )
                 except discord.errors.NotFound:
                     target = self.bot.get_channel(channel.id)
                     msg = await target.send(data["message"])

--- a/bot/cogs/views/sticky.py
+++ b/bot/cogs/views/sticky.py
@@ -41,7 +41,7 @@ class StickyPagination(discord.ui.View):
         self.message = None
 
     async def construct_pages(self, ctx: commands.Context, list_data: List[Dict[str, Any]]) -> None:
-        N_LIST = 5
+        N_LIST = 10
 
         total_data = len(list_data)
         if total_data % N_LIST:
@@ -51,7 +51,10 @@ class StickyPagination(discord.ui.View):
 
         if self.total_page_count:
             for page_num in range(self.total_page_count):
-                page_data_list = [list_data[(page_num * N_LIST) : (page_num * N_LIST) + N_LIST]]
+                page_data_list = [
+                    list_data[(page_num * N_LIST) : (page_num * N_LIST) + N_LIST // 2],
+                    list_data[(page_num * N_LIST) + N_LIST // 2 : (page_num + 1) * N_LIST],
+                ]
 
                 embed = discord.Embed(
                     color=discord.Color.gold(),
@@ -61,20 +64,19 @@ class StickyPagination(discord.ui.View):
                 )
 
                 for sticky_data_list in page_data_list:
+                    if sticky_data_list == page_data_list[1] and len(page_data_list[1]) == 0:
+                        continue
+
                     field_value = ""
                     field_name = ""
 
                     if sticky_data_list == page_data_list[0]:
-                        field_name = "Channel  Name"
+                        field_name = "Channel Name"
                     else:
-                        field_name = ""
+                        field_name = "_ _"
 
                     for sticky_data in sticky_data_list:
-                        if len(sticky_data["message"]) > 250:
-                            message = sticky_data["message"][:250] + "..."
-                        else:
-                            message = sticky_data["message"]
-                        row_string = f"<#{sticky_data['channel_id']}> \n > {message} \n\n"
+                        row_string = f"<#{sticky_data['channel_id']}>\n"
                         field_value += row_string
 
                     embed.add_field(name=field_name, value=field_value)

--- a/bot/cogs/views/sticky.py
+++ b/bot/cogs/views/sticky.py
@@ -41,7 +41,7 @@ class StickyPagination(discord.ui.View):
         self.message = None
 
     async def construct_pages(self, ctx: commands.Context, list_data: List[Dict[str, Any]]) -> None:
-        N_LIST = 20
+        N_LIST = 5
 
         total_data = len(list_data)
         if total_data % N_LIST:
@@ -51,10 +51,7 @@ class StickyPagination(discord.ui.View):
 
         if self.total_page_count:
             for page_num in range(self.total_page_count):
-                page_data_list = [
-                    list_data[(page_num * N_LIST) : (page_num * N_LIST) + N_LIST // 2],
-                    list_data[(page_num * N_LIST) + N_LIST // 2 : (page_num + 1) * N_LIST],
-                ]
+                page_data_list = [list_data[(page_num * N_LIST) : (page_num * N_LIST) + N_LIST]]
 
                 embed = discord.Embed(
                     color=discord.Color.gold(),
@@ -64,23 +61,20 @@ class StickyPagination(discord.ui.View):
                 )
 
                 for sticky_data_list in page_data_list:
-                    if sticky_data_list == page_data_list[1] and len(page_data_list[1]) == 0:
-                        continue
-
                     field_value = ""
                     field_name = ""
 
                     if sticky_data_list == page_data_list[0]:
-                        field_name = "Channel  |  Message"
+                        field_name = "Channel  Name"
                     else:
-                        field_name = "|"
+                        field_name = ""
 
                     for sticky_data in sticky_data_list:
-                        if len(sticky_data["message"]) > 25:
-                            message = sticky_data["message"][:20] + "..."
+                        if len(sticky_data["message"]) > 250:
+                            message = sticky_data["message"][:250] + "..."
                         else:
                             message = sticky_data["message"]
-                        row_string = f"<#{sticky_data['channel_id']}> message={message}\n"
+                        row_string = f"<#{sticky_data['channel_id']}> \n > {message} \n\n"
                         field_value += row_string
 
                     embed.add_field(name=field_name, value=field_value)


### PR DESCRIPTION
Command:
- `/sticky re-send` (Re-send sticky message to specific channel if accidentally deleted)

Permission **MANAGE_CHANNELS** is **Required** for execute the command.

Minor change:
- User can still edit/remove/purge sticky message event the message has been deleted.
- Change UI display for command `/sticky list`